### PR TITLE
bootstrap-4-react aus json entfernt

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.8.3",
     "bootstrap": "^4.6.0",
-    "bootstrap-4-react": "^0.0.59",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-bootstrap": "^1.5.2",


### PR DESCRIPTION
altes npm packet

bootstrap-4-react entfernt
da jetzt react-bootstrap benutzt wird