### PR TITLE
Spielfeld div' abgerundet, Modal's grauen Hintergrund entfernt

### DIFF
--- a/src/components/Spielseite.css
+++ b/src/components/Spielseite.css
@@ -1,13 +1,9 @@
-/* .grid-container {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  grid-template-rows: repeat(4, 1fr);
-  text-align: center;
-} */
-
 .grid-container > div {
   height: 50px;
-  border: 2px solid red
+  width: 50px;
+  border: 4px solid gray;
+  background-color: lightgray;
+  border-radius: 100%;
 }
 
 .grid-container {

--- a/src/components/Startseite.css
+++ b/src/components/Startseite.css
@@ -1,0 +1,1 @@
+.modal-backdrop { background-color: transparent }

--- a/src/components/Startseite.js
+++ b/src/components/Startseite.js
@@ -1,8 +1,9 @@
 import Spielanleitung from './Spielanleitung'
+import './Startseite.css'
 
 const Startseite = props => {
   return (
-    <div>
+    <div className="Startseite">
       <h1>Willkommen auf die Startseite!</h1>
       <button onClick={() => props.setPage('spielseite')}>
         Gehe zum Spiel!


### PR DESCRIPTION
provisorisch einfach mal die Spielfeld div's abgerundet, border und background-color gegeben

den grauen hintergrund von den Modals entfernt, sonst sieht man dass Spielfeld/Hintergrundbild ja immer nur in Grau,
da man ja immer eine Aufforderrung zum Würfeln, Frage,... bekommt

backdrop-color auf transparent gestellt (nicht display:none) -->
man kann bis auf das Spielanleitungs die Modals nicht wegdrücken indem man daneben drückt oder ESC
(funktioniert also wie bisher nur ohne grau)