### PR TITLE
Der Typ des Spielfeldes wird jetzt anhand des Array-Elements ermittelt

### DIFF
--- a/src/components/QuizFrage.js
+++ b/src/components/QuizFrage.js
@@ -11,13 +11,11 @@ const QuizFrage = () => {
   const handleClose = () => setShow(false);
 
   const fragen = useSelector(state => state.fragen);
-
   const spielfigurPosition = useSelector(state => state.spielfigurPosition);
+  const spielfeldArray = useSelector(state => state.spielfeldArray);
 
   // Thema anhand der Spielfigurposition ermitteln
-  const thema = spielfigurPosition % 3 === 0 ? 'html' :
-    spielfigurPosition % 3 === 1 ? 'css' :
-    'javascript';
+  const thema = spielfeldArray[spielfigurPosition];
 
   const fragenEinesThemas = fragen.filter(element => element.thema === thema);
 

--- a/src/components/Spielfeld.js
+++ b/src/components/Spielfeld.js
@@ -1,13 +1,12 @@
 import './Spielfeld.css';
+import { useSelector } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFileCode } from '@fortawesome/free-regular-svg-icons';
 import { faCircle } from '@fortawesome/free-solid-svg-icons';
 import { faCss3, faJs } from '@fortawesome/free-brands-svg-icons';
 
 const Spielfeld = props => {
-  const thema = props.order % 3 === 0 ? 'html' :
-    props.order % 3 === 1 ? 'css' :
-      'javascript';
+  const spielfeldArray = useSelector(state => state.spielfeldArray);
 
   return (
     <div className={`spielfeld-${props.order}`}>
@@ -25,7 +24,7 @@ const Spielfeld = props => {
             <FontAwesomeIcon icon={faCircle} style={{ color: "orange" }} />
             <FontAwesomeIcon icon={faJs} inverse transform="shrink-6" />
           </span>
-        }[thema]
+        }[spielfeldArray[props.order]]
       }
     </div>
   );

--- a/src/reducers/spielReducer.js
+++ b/src/reducers/spielReducer.js
@@ -9,9 +9,10 @@ import {
 const initialState = {
   // page legt fest, welche Seite ganz oben im App gerendert wird
   page: 'startseite',
-  // Spielfelder-Array.
-  // Später könnte drin die Feldtypen sein, z.B. Thema1, Thema2, Aktion
-  spielfeldArray: Array(60).fill(null),
+  // Spielfelder-Array. Die Elemente repräsentieren die Feldtypen
+  spielfeldArray: Array(60).fill(null).map((element, index) => index % 3 === 0 ? 'html' :
+    index % 3 === 1 ? 'css' :
+    'javascript'),
   // Eine Zahl, die dem Index von spielfeldArray entspricht und die Position von Spielfigur angibt.
   spielfigurPosition: 0,
   // Die Variable legt fest, welches Popup gerendert wird.


### PR DESCRIPTION
So war das ursprünglich gedacht. Jetzt kann man es zentral nur an einer Stelle (initialState in Reducer) anpassen.