### PR TITLE
Startseite warnung

### DIFF
--- a/src/thunks/thunks.js
+++ b/src/thunks/thunks.js
@@ -37,6 +37,9 @@ export const setSpielfigurPositionen = object => dispatch => dispatch(actionSetS
 // websocket
 
 export const connectWebsocket = () => dispatch => {
+  // Wenn es keine Verbindung zum websocket-Server gibt
+  ws.onclose = () => dispatch(actionSetStartseiteLog('Keine Verbindung zum Spielserver.'));
+  
   ws.onmessage = message => {
     const response = JSON.parse(message.data);
     console.log(response);


### PR DESCRIPTION
Wenn keine Verbinung zum websocket-Server vorhanden ist oder wenn wegen einer ungültigen Aktion/Klick auf der Startseite eine Mitteilung/Warnung vom Server kommt, wird es in textarea angezeigt.