### PR TITLE
Spielanleitung wird nicht mehr durchsichtig

### DIFF
--- a/src/components/Spielanleitung.js
+++ b/src/components/Spielanleitung.js
@@ -21,7 +21,7 @@ const Spielanleitung = props => {
         Spielanleitung
       </Button>
 
-      <Modal show={show} onHide={handleClose}>
+      <Modal className="spielanleitung-modal" show={show} onHide={handleClose}>
 
         <Modal.Header>
           <Modal.Title>Anleitung und Spielregeln: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;

--- a/src/components/Startseite.css
+++ b/src/components/Startseite.css
@@ -31,6 +31,9 @@ margin-bottom: 20%;
   .modal-dialog {
     opacity: 0.7;
   }
+  .spielanleitung-modal .modal-dialog {
+    opacity: 1.0;
+  }
   .modal-title.h4 {
     font-size: 1rem;
   }


### PR DESCRIPTION
problem war immer dass wir den klassennamen auf der gesamten Komponente hatten
sprich, bei section oder div

muss direkt zu <Modal classNam....> dann klappts